### PR TITLE
feature: Downgrade version of jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 source "https://rubygems.org"
-gem "jekyll", "3.8.5"
-
+# gem "jekyll", "3.8.5"
 # gem "github-pages", group: :jekyll_plugins
 
 gemspec

--- a/rivet-jekyll-theme.gemspec
+++ b/rivet-jekyll-theme.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README)!i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.8"
+  spec.add_runtime_dependency "jekyll", "~> 3.5"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.0"
 end


### PR DESCRIPTION
Trying to fix the dependency errors I'm seeing using the theme locally. 
Using https://github.com/jekyll/minima as an example (the default theme) I made the build more generic and am not specifying the version of bundler which might have been not optimal anyway.
