### PR TITLE
feature: Make theme usable on user and project sites

### DIFF
--- a/_includes/site/header.html
+++ b/_includes/site/header.html
@@ -14,7 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
         </svg>
     </div>
     <span class="rvt-header__title">
-        <a href="/">{{ site.title }}</a>
+        <a href="{{ site.baseurl }}/">{{ site.title }}</a>
     </span>
     {% include site/header_menu.html %}
 </header>

--- a/_includes/site/icons.html
+++ b/_includes/site/icons.html
@@ -2,4 +2,4 @@
 Copyright (C) 2019 The Trustees of Indiana University
 SPDX-License-Identifier: BSD-3-Clause
 {% endcomment %}
-<link rel="icon" href="/assets/favicon.ico">
+<link rel="icon" href="{{ site.baseurl }}/assets/favicon.ico">

--- a/_includes/site/scripts.html
+++ b/_includes/site/scripts.html
@@ -2,5 +2,5 @@
 Copyright (C) 2019 The Trustees of Indiana University
 SPDX-License-Identifier: BSD-3-Clause
 {% endcomment %}
-<script src="/assets/js/libs/rivet.min.js"></script>
+<script src="{{ site.baseurl }}/assets/js/libs/rivet.min.js"></script>
 {% include site/scripts-extra.html %}

--- a/_includes/site/styles.html
+++ b/_includes/site/styles.html
@@ -2,7 +2,7 @@
 Copyright (C) 2019 The Trustees of Indiana University
 SPDX-License-Identifier: BSD-3-Clause
 {% endcomment %}
-<link rel="stylesheet" href="/assets/css/libs/rivet.min.css">
-<link rel="stylesheet" href="/assets/css/libs/rivet-shell.min.css">
-<link rel="stylesheet" href="/assets/css/rivet-jekyll-theme.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/libs/rivet.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/libs/rivet-shell.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/rivet-jekyll-theme.css">
 {% include site/styles-extra.html %}


### PR DESCRIPTION
Add {{ site.baseurl }} to asset links

Local testing: 
Test like a User or Project
`$ bundle exec jekyll serve --baseurl '/ccore' --port <port>`

Test like you have a subdomain:
`$ bundle exec jekyll serve --port <port>`